### PR TITLE
Support configuring openai baseURL

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -34,6 +34,7 @@ interface CannoliSettings {
 	groqAPIKey: string;
 	groqTemperature: number;
 	openaiAPIKey: string;
+	openaiBaseURL: string;
 	costThreshold: number;
 	defaultModel: string;
 	defaultTemperature: number;
@@ -65,6 +66,7 @@ const DEFAULT_SETTINGS: CannoliSettings = {
 	groqAPIKey: "",
 	groqTemperature: 1,
 	openaiAPIKey: "",
+	openaiBaseURL: "",
 	costThreshold: 0.5,
 	defaultModel: "gpt-3.5-turbo",
 	defaultTemperature: 1,
@@ -452,6 +454,7 @@ export default class Cannoli extends Plugin {
 						apiKey: this.settings.openaiAPIKey,
 						model: this.settings.defaultModel,
 						temperature: this.settings.defaultTemperature,
+						baseURL: this.settings.openaiBaseURL,
 					};
 				case "ollama":
 					return {
@@ -1117,6 +1120,21 @@ class CannoliSettingTab extends PluginSettingTab {
 									DEFAULT_SETTINGS.defaultTemperature;
 								await this.plugin.saveSettings();
 							}
+						})
+				);
+			// openai base url setting
+			new Setting(containerEl)
+				.setName("Openai base url")
+				.setDesc(
+					"This url will be used to make openai llm calls against a different endpoint. This is useful for switching to an azure enterprise endpoint, or, some other openai compatible service."
+				)
+				.addText((text) =>
+					text
+						.setValue(this.plugin.settings.openaiBaseURL)
+						.setPlaceholder("https://api.openai.com/v1/")
+						.onChange(async (value) => {
+							this.plugin.settings.openaiBaseURL = value;
+							await this.plugin.saveSettings();
 						})
 				);
 		} else if (this.plugin.settings.llmProvider === "ollama") {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -74,6 +74,7 @@ export type GenericCompletionResponse = {
 // @deprecated
 export const makeSampleConfig = (): GenericModelConfig => ({
 	apiKey: undefined,
+	baseURL: undefined,
 	model: "",
 	frequency_penalty: undefined,
 	presence_penalty: undefined,
@@ -172,9 +173,11 @@ export class LLMProvider {
 			case "openai":
 				return new ChatOpenAI({
 					apiKey: config.apiKey,
-					azureOpenAIBasePath: config.baseURL,
 					model: config.model,
 					temperature: config.temperature,
+					configuration: {
+						baseURL: config.baseURL,
+					}
 				});
 			case "ollama":
 				if (args?.hasFunctionCall) {


### PR DESCRIPTION
This allows you to redirect all openai LLM requests to other openai compatible services, or enterprise versions of openai.

Adding first class support to other providers is still preferable so that you can have distinct settings per provider, but this will help bridge the gap until we add first class support.

These settings enable communication with LM Studio, for example

<img width="787" alt="Screenshot 2024-05-15 at 11 14 42 AM" src="https://github.com/DeabLabs/cannoli/assets/8948924/8c8f62b0-2acc-40f7-bd9e-8fae64b16b66">

base url: http://localhost:1234/v1/
(be sure CORS is enabled in LM Studio server settings)