### PR TITLE
Fix validator for mcp-servers/:id 

### DIFF
--- a/packages/cannoli-server/src/routes/servers.ts
+++ b/packages/cannoli-server/src/routes/servers.ts
@@ -20,7 +20,7 @@ import {
 import { McpProxyServer } from "src/types";
 
 // Define input schemas
-const ServerIdParamSchema = z.string();
+const ServerIdParamSchema = z.object({ id: z.string() });
 
 // Define response schemas
 const ServersListResponseSchema = SuccessResponseSchema.extend({


### PR DESCRIPTION
`zValidator` needs a schema for the entire params object.

Hono’s c.req.param() is overloaded: param(name) returns a string, while param() returns the entire params object as used by `zValidator`


Resources:
* https://hono.dev/docs/api/request#param
* https://github.com/honojs/middleware/blob/b6974e9b14adb4bc9f96b0d72b6bfafd5daf7963/packages/zod-validator/src/index.ts#L33
* https://github.com/honojs/hono/blob/2f489b3562cd0d29075062b2ea0648ab92b88727/src/types.ts#L1927